### PR TITLE
Fixed class name of YAMLLintRunner

### DIFF
--- a/lib/pronto/yamllint_runner.rb
+++ b/lib/pronto/yamllint_runner.rb
@@ -3,7 +3,7 @@ require 'shellwords'
 
 module Pronto
   # runner for yamllint
-  class YAMLLintRunner < Runner
+  class YAMLLint < Runner
     def yamllint_opts
       ENV['YAMLLINT_OPTS']
     end

--- a/pronto-yamllint.gemspec
+++ b/pronto-yamllint.gemspec
@@ -3,7 +3,7 @@ require 'pronto/yamllint_version'
 
 Gem::Specification.new do |s|
   s.name        = 'pronto-yamllint'
-  s.version     = '0.1.0'
+  s.version     = '0.1.1'
   s.date        = '2017-10-25'
   s.summary     = 'Pronto runner for yamllint'
   s.description = 'Enables pronto to check .yaml files using yamllint'


### PR DESCRIPTION
In order to preserve the same naming convention for pronto runners, the class name of `YAMLLintRunner` was changed to `YAMLLint`. The pronto runners does not include `Runner` in the class name. The pronto class names consists only of linter's name.

#### Example
* [pronto-rubocop](https://github.com/prontolabs/pronto-rubocop/blob/master/lib/pronto/rubocop.rb#L5)
* [pronto-haml](https://github.com/prontolabs/pronto-haml/blob/master/lib/pronto/haml.rb#L5)