### PR TITLE
Depend on pronto 0.11

### DIFF
--- a/pronto-yamllint.gemspec
+++ b/pronto-yamllint.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.requirements << 'yamllint (in PATH)'
-  s.add_dependency('pronto', '~> 0.10.0')
+  s.add_dependency('pronto', '~> 0.11.0')
 end


### PR DESCRIPTION
A new version of `pronto` has been released. Among others, it is now compatible with `rails` 6.1.

This change bumps the dependency on `pronto` to `~> 0.11.0`.